### PR TITLE
Add ssbnz link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Meta documentation for the Scuttlebutt ecosystem.
 
 Includes developer documentation for the [Node.js](https://dev.scuttlebutt.nz/#/javascript/), [Go](https://dev.scuttlebutt.nz/#/golang/), [Rust](https://dev.scuttlebutt.nz/#/rust/) and [Python](https://dev.scuttlebutt.nz/#/python/) implementations of the Scuttlebutt Protocol.
 
+If you want to know more about Secure Scuttlebutt in general, visit the [main site](https://ssb.nz).
+
 ## Setup
 
 Uses [docsify](https://docsify.js.org) for a happy, no-build setup.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,10 @@ Welcome traveller! **Secure Scuttlebutt (SSB)** is a project which spans several
 This documentation is a meta-guide designed to familiarise you with some core concepts,
 and help you find the current tools in you language of choice.
 
+More information:
+* If you are looking for an **implementation-agnostic** protocol specification, see the [Scuttlebutt Protocol Guide](https://ssbc.github.io/scuttlebutt-protocol-guide/) site
+* If you want to learn more about Scuttlebutt in general (such as talks and how to get started), go visit the [main site](https://ssb.nz).
+
 ## Implementations
 
 Jump straight in?

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,6 +1,6 @@
 
-- [**ssb.nz**](https://ssbc.github.io/scuttlebutt-protocol-guide/)
-- [**Protocol Guide**](https://ssbc.github.io/scuttlebutt-protocol-guide/)
+- [**scuttlebutt.nz** ⧉](https://ssbc.github.io/scuttlebutt-protocol-guide/)
+- [**Protocol Guide** ⧉](https://ssbc.github.io/scuttlebutt-protocol-guide/)
 - [**Implementations**](#implementations)
 
   - [Node.js](javascript/)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,4 +1,6 @@
 
+- [**ssb.nz**](https://ssbc.github.io/scuttlebutt-protocol-guide/)
+- [**Protocol Guide**](https://ssbc.github.io/scuttlebutt-protocol-guide/)
 - [**Implementations**](#implementations)
 
   - [Node.js](javascript/)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -2,7 +2,7 @@
 - [**Implementations**](#implementations)
 
   - [Node.js](javascript/)
-  - [Go lang](golang/)
+  - [Golang](golang/)
   - [Rust](rust/)
   - [Python](python/)
 


### PR DESCRIPTION
one of the outcomes of the documentation sprint: sprinkling a few links inside the existing dev docs to make the other sites easier to find :)

in particular, one good fix is adding a link to the protocol guide inside the developer docs :~

there's a preview embedded below![image](https://user-images.githubusercontent.com/3862362/145424136-6b6bf1a9-c503-48ce-acfd-e765bc52cd33.png)